### PR TITLE
Removed quotes around 'Rose and Crown'

### DIFF
--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -67,7 +67,7 @@
 			<p>“Well,” said the Bargee, more gently, “cut along, then, and don’t you do it again, that’s all.”</p>
 			<p>The children hurried up the bank.</p>
 			<p>“Chuck us a coat, M’ria,” shouted the man. And a red-haired woman in a green plaid shawl came out from the cabin door with a baby in her arms and threw a coat to him. He put it on, climbed the bank, and slouched along across the bridge towards the village.</p>
-			<p>“You’ll find me up at the ‘Rose and Crown’ when you’ve got the kid to sleep,” he called to her from the bridge.</p>
+			<p>“You’ll find me up at the Rose and Crown when you’ve got the kid to sleep,” he called to her from the bridge.</p>
 			<p>When he was out of sight the children slowly returned. Peter insisted on this.</p>
 			<p>“The canal may belong to him,” he said, “though I don’t believe it does. But the bridge is everybody’s. Doctor Forrest told me it’s public property. I’m not going to be bounced off the bridge by him or anyone else, so I tell you.”</p>
 			<p>Peter’s ear was still sore and so were his feelings.</p>
@@ -120,11 +120,11 @@
 			<p>Bobbie dropped the dog.</p>
 			<p>“All right, old man. Good dog,” said she. “Here⁠—give me the baby, Peter; you’re so wet you’ll give it cold.”</p>
 			<p>Peter was only too glad to hand over the strange little bundle that squirmed and whimpered in his arms.</p>
-			<p>“Now,” said Bobbie, quickly, “you run straight to the ‘Rose and Crown’ and tell them. Phil and I will stay here with the precious. Hush, then, a dear, a duck, a darling! Go <em>now</em>, Peter! Run!”</p>
+			<p>“Now,” said Bobbie, quickly, “you run straight to the Rose and Crown and tell them. Phil and I will stay here with the precious. Hush, then, a dear, a duck, a darling! Go <em>now</em>, Peter! Run!”</p>
 			<p>“I can’t run in these things,” said Peter, firmly; “they’re as heavy as lead. I’ll walk.”</p>
 			<p>“Then <em>I’ll</em> run,” said Bobbie. “Get on the bank, Phil, and I’ll hand you the dear.”</p>
-			<p>The baby was carefully handed. Phyllis sat down on the bank and tried to hush the baby. Peter wrung the water from his sleeves and knickerbocker legs as well as he could, and it was Bobbie who ran like the wind across the bridge and up the long white quiet twilight road towards the ‘Rose and Crown.’</p>
-			<p>There is a nice old-fashioned room at the ‘Rose and Crown; where bargees and their wives sit of an evening drinking their supper beer, and toasting their supper cheese at a glowing basketful of coals that sticks out into the room under a great hooded chimney and is warmer and prettier and more comforting than any other fireplace <em>I</em> ever saw.</p>
+			<p>The baby was carefully handed. Phyllis sat down on the bank and tried to hush the baby. Peter wrung the water from his sleeves and knickerbocker legs as well as he could, and it was Bobbie who ran like the wind across the bridge and up the long white quiet twilight road towards the Rose and Crown.</p>
+			<p>There is a nice old-fashioned room at the Rose and Crown; where bargees and their wives sit of an evening drinking their supper beer, and toasting their supper cheese at a glowing basketful of coals that sticks out into the room under a great hooded chimney and is warmer and prettier and more comforting than any other fireplace <em>I</em> ever saw.</p>
 			<p>There was a pleasant party of barge people round the fire. You might not have thought it pleasant, but they did; for they were all friends or acquaintances, and they liked the same sort of things, and talked the same sort of talk. This is the real secret of pleasant society. The Bargee Bill, whom the children had found so disagreeable, was considered excellent company by his mates. He was telling a tale of his own wrongs⁠—always a thrilling subject. It was his barge he was speaking about.</p>
 			<p>“And ’e sent down word ‘paint her inside hout,’ not namin’ no colour, d’ye see? So I gets a lotter green paint and I paints her stem to stern, and I tell yer she looked A1. Then ’e comes along and ’e says, ‘Wot yer paint ’er all one colour for?’ ’e says. And I says, says I, ‘Cause I thought she’d look fust-rate,’ says I, ‘and I think so still.’ An’ he says, ‘<em>Dew</em> yer? Then ye can just pay for the bloomin’ paint yerself,’ says he. An’ I ’ad to, too.” A murmur of sympathy ran round the room. Breaking noisily in on it came Bobbie. She burst open the swing door⁠—crying breathlessly:⁠—</p>
 			<p>“Bill! I want Bill the Bargeman.”</p>


### PR DESCRIPTION
As flagged on the forum by rfrank. No need for quotes around this pub name, and there was one mismatched quote. So all quotes around the name removed. I don't imagine that we need an SE semantic for hotel names?